### PR TITLE
Bring _measureCollector to front after move event

### DIFF
--- a/src/leaflet-measure.js
+++ b/src/leaflet-measure.js
@@ -241,6 +241,7 @@ L.Control.Measure = L.Control.extend({
       this._measureDrag.setLatLng(evt.latlng);
     }
     this._measureDrag.bringToFront();
+    this._measureCollector.bringToFront();
   },
   // handler for both double click and clicking finish button
   // do final calc and finish out current measure, clear dom and internal state, add permanent map features


### PR DESCRIPTION
In the current Leaflet 1.0.0 beta, leaflet-measure is broken because click events are not being propagated to the _measureCollector layer.  This probably has to do with the Layer and Pane enhancements in 1.0.0.  This change corrects the problem by bringing _measureCollector to front, ensuring that it can still catch click events.