### PR TITLE
Remove measurement geometries when removing the control

### DIFF
--- a/src/leaflet-measure.js
+++ b/src/leaflet-measure.js
@@ -261,7 +261,7 @@ L.Control.Measure = L.Control.extend({
         humanize: humanize
       });
     } else if (latlngs.length === 2) {
-      resultFeature = L.polyline(latlngs, this._symbols.getSymbol('resultLine')).addTo(this._map);
+      resultFeature = L.polyline(latlngs, this._symbols.getSymbol('resultLine'));
       popupContent = linePopupTemplate({
         model: _.extend({}, calced, this._getMeasurementDisplayStrings(calced)),
         humanize: humanize
@@ -294,11 +294,11 @@ L.Control.Measure = L.Control.extend({
       L.DomEvent.on(deleteLink, 'click', L.DomEvent.stop);
       L.DomEvent.on(deleteLink, 'click', function () {
         // TODO. maybe remove any event handlers on zoom and delete buttons?
-        this._map.removeLayer(resultFeature);
+        this._layer.removeLayer(resultFeature);
       }, this);
     }
 
-    resultFeature.addTo(this._map);
+    resultFeature.addTo(this._layer);
     resultFeature.bindPopup(popupContainer, this.options.popupOptions);
     resultFeature.openPopup(resultFeature.getBounds().getCenter());
   },


### PR DESCRIPTION
Add measure result features to `_layer`, not directly to `_map`. This allows cleanup in `onRemove()` to remove those features, which are otherwise not tracked.

Resolves issue #21.