### PR TITLE
move i18n-2 from devDependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "color": "^0.8.0",
     "geocrunch": "^0.1.1",
     "humanize": "0.0.9",
+    "i18n-2": "^0.6.2",
     "leaflet": "^0.7.3",
     "underscore": "^1.7.0"
   },
@@ -44,8 +45,7 @@
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-jscs": "^1.2.0",
     "grunt-release": "^0.11.0",
-    "svg2png": "^1.1.0",
-    "i18n-2": "^0.6.2"
+    "svg2png": "^1.1.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Moved `i18n-2` module from `devDependency to `dependency`.

This is required for apps that use browserify:
```
Running "browserify:dev" (browserify) task
>> Error: Cannot find module 'i18n-2' from 'C:\dev\js-mapbootstrap\node_modules\leaflet-measure\src'
```
