### PR TITLE
Fixed decimal point/thousand separator

### DIFF
--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -28,6 +28,6 @@ module.exports = {
     'sqfeet': 'Quadratfuß',
     'sqmeters': 'Quadratmeter',
     'sqmiles': 'Quadratmeilen',
-    'decPoint': '.',
-    'thousandsSep': ','
+    'decPoint': ',',
+    'thousandsSep': '.'
 };


### PR DESCRIPTION
I accidentally had 'decPoint' and 'thousandsSep' the wrong way round.