### PR TITLE
[Fix] Upgrade dependency which causes Webpack compile error on import of this package

### DIFF
--- a/dist/leaflet-measure.js
+++ b/dist/leaflet-measure.js
@@ -725,11 +725,11 @@ for (var func in conversions) {
   // export rgb2hsl and ["rgb"]["hsl"]
   convert[from] = convert[from] || {};
 
-  convert[from][to] = convert[func] = (function(func) { 
+  convert[from][to] = convert[func] = (function(func) {
     return function(arg) {
       if (typeof arg == "number")
         arg = Array.prototype.slice.call(arguments);
-      
+
       var val = conversions[func](arg);
       if (typeof val == "string" || val === undefined)
         return val; // keyword
@@ -757,12 +757,12 @@ Converter.prototype.routeSpace = function(space, args) {
    }
    // color.rgb(10, 10, 10)
    if (typeof values == "number") {
-      values = Array.prototype.slice.call(args);        
+      values = Array.prototype.slice.call(args);
    }
 
    return this.setValues(space, values);
 };
-  
+
 /* Set the values for a space, invalidating cache */
 Converter.prototype.setValues = function(space, values) {
    this.space = space;
@@ -2112,7 +2112,7 @@ exports.degrees = {
     return result.value;
   };
 
-  // Shuffle an array, using the modern version of the 
+  // Shuffle an array, using the modern version of the
   // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
   _.shuffle = function(obj) {
     var rand;
@@ -3339,7 +3339,7 @@ exports.degrees = {
 
       // Seconds since UNIX epoch
       U: function () { return jsdate.getTime() / 1000 || 0; }
-    };    
+    };
 
     return format.replace(formatChr, formatChrCb);
   };
@@ -3532,7 +3532,7 @@ exports.degrees = {
   /**
    * Replaces line breaks in plain text with appropriate HTML
    * A single newline becomes an HTML line break (<br />) and a new line followed by a blank line becomes a paragraph break (</p>).
-   * 
+   *
    * For example:
    * If value is Joel\nis a\n\nslug, the output will be <p>Joel<br />is a</p><p>slug</p>
    */
@@ -3794,7 +3794,7 @@ i18n.prototype = {
 	setLocaleFromSessionVar: function (req) {
 		req = req || this.request;
 
-		if (!req || !req.session || !req.session[this.sessionVarName]) {		
+		if (!req || !req.session || !req.session[this.sessionVarName]) {
 			return;
 		}
 
@@ -4003,7 +4003,7 @@ i18n.prototype = {
 				console.log('creating locales dir in: ' + this.directory);
 			}
 
-			fs.mkdirSync(this.directory, 0755);
+			fs.mkdirSync(this.directory, 0o755);
 		}
 
 		// Initialize the locale if didn't exist already
@@ -4548,20 +4548,20 @@ var sprintf = (function() {
 
 	// convert object to simple one line string without indentation or
 	// newlines. Note that this implementation does not print array
-	// values to their actual place for sparse arrays. 
+	// values to their actual place for sparse arrays.
 	//
 	// For example sparse array like this
 	//    l = []
 	//    l[4] = 1
 	// Would be printed as "[1]" instead of "[, , , , 1]"
-	// 
-	// If argument 'seen' is not null and array the function will check for 
+	//
+	// If argument 'seen' is not null and array the function will check for
 	// circular object references from argument.
 	str_format.object_stringify = function(obj, depth, maxdepth, seen) {
 		var str = '';
 		if (obj != null) {
 			switch( typeof(obj) ) {
-			case 'function': 
+			case 'function':
 				return '[Function' + (obj.name ? ': '+obj.name : '') + ']';
 			    break;
 			case 'object':
@@ -4585,17 +4585,17 @@ var sprintf = (function() {
 				} else { // object
 					str += '{';
 					var arr = []
-					for (var k in obj) { 
+					for (var k in obj) {
 						if(obj.hasOwnProperty(k)) {
 							if (seen && seen.indexOf(obj[k]) >= 0) arr.push(k + ': [Circular]');
-							else arr.push(k +': ' +str_format.object_stringify(obj[k], depth+1, maxdepth, seen)); 
+							else arr.push(k +': ' +str_format.object_stringify(obj[k], depth+1, maxdepth, seen));
 						}
 					}
 					str += arr.join(', ') + '}';
 				}
 				return str;
 				break;
-			case 'string':				
+			case 'string':
 				return '"' + obj + '"';
 				break
 			}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "color": "^0.8.0",
     "geocrunch": "^0.1.1",
     "humanize": "0.0.9",
-    "i18n-2": "git+https://github.com/annelorraineuy/i18n-node-2.git",
+    "i18n-2": "0.7.1",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "color": "^0.8.0",
     "geocrunch": "^0.1.1",
     "humanize": "0.0.9",
-    "i18n-2": "^0.6.3",
+    "i18n-2": "git+https://github.com/annelorraineuy/i18n-node-2.git",
     "underscore": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upon importing leaflet-measure, the dependency `i18n-2` caused a Webpack compile error. See: https://github.com/jeresig/i18n-node-2/pull/108

`i18n-2` has merged that PR and upgraded.

**Purpose of this PR:**
- upgrade `i18n-2` which fixes Webpack compile error on import
- implement the same fix regarding fs write mode for node js