### PR TITLE
add disable

### DIFF
--- a/src/leaflet-measure.js
+++ b/src/leaflet-measure.js
@@ -46,7 +46,8 @@ L.Control.Measure = L.Control.extend({
   },
   initialize: function(options) {
     L.setOptions(this, options);
-    const { activeColor, completedColor } = this.options;
+    const { activeColor, completedColor, disabledClassName } = this.options;
+    this.disabledClassName = disabledClassName;
     this._symbols = new Symbology({ activeColor, completedColor });
     this.options.units = L.extend({}, units, this.options.units);
   },
@@ -61,6 +62,25 @@ L.Control.Measure = L.Control.extend({
   onRemove: function(map) {
     map.off('click', this._collapse, this);
     map.removeLayer(this._layer);
+  },
+  disable: function() {
+    this._disabled = true;
+    this._updateDisabled();
+    return this;
+  },
+  enable: function() {
+    this._disabled = false;
+    this._updateDisabled();
+    return this;
+  },
+  _updateDisabled: function() {
+    const className = this.disabledClassName || 'leaflet-disabled';
+
+    L.DomUtil.removeClass(this._container, className);
+
+    if (this._disabled) {
+      L.DomUtil.addClass(this._container, className);
+    }
   },
   _initLayout: function() {
     const className = this._className,
@@ -109,8 +129,10 @@ L.Control.Measure = L.Control.extend({
     L.DomEvent.on($finish, 'click', this._handleMeasureDoubleClick, this);
   },
   _expand: function() {
-    dom.hide(this.$toggle);
-    dom.show(this.$interaction);
+    if (!this._disabled) {
+      dom.hide(this.$toggle);
+      dom.show(this.$interaction);
+    }
   },
   _collapse: function() {
     if (!this._locked) {

--- a/src/leaflet-measure.js
+++ b/src/leaflet-measure.js
@@ -75,9 +75,7 @@ L.Control.Measure = L.Control.extend({
   },
   _updateDisabled: function() {
     const className = this.disabledClassName || 'leaflet-disabled';
-
     L.DomUtil.removeClass(this._container, className);
-
     if (this._disabled) {
       L.DomUtil.addClass(this._container, className);
     }


### PR DESCRIPTION
add the function to disable and enable the leaflet-measure button

if disabled, the button would not expand when mouse hover

referenced from a commit in Leaflet Zoom Control : ```https://github.com/Leaflet/Leaflet/blob/aace5b278e3584da2c2aa477964d7740c7870e4f/src/control/Control.Zoom.js```